### PR TITLE
Try tower service hack

### DIFF
--- a/trackinfo-tonic/Cargo.lock
+++ b/trackinfo-tonic/Cargo.lock
@@ -733,8 +733,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.4.1"
-source = "git+https://github.com/liufuyang/tonic.git?branch=remote-timeout-header-from-reserved-list#3170af236b108faf33c211b3d65d88cfd9076062"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556dc31b450f45d18279cfc3d2519280273f460d5387e6b7b24503e65d206f8b"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -850,12 +851,14 @@ dependencies = [
 name = "trackinfo-tonic"
 version = "0.1.0"
 dependencies = [
+ "http",
  "prost",
  "prost-types",
  "rb62",
  "tokio",
  "tonic",
  "tonic-build",
+ "tower-service",
 ]
 
 [[package]]

--- a/trackinfo-tonic/Cargo.toml
+++ b/trackinfo-tonic/Cargo.toml
@@ -13,10 +13,14 @@ path = "src/server.rs"
 [dependencies]
 # gid-to-uuid = { path = "../gid-to-uuid" }
 rb62 = { git = 'https://github.com/liufuyang/rb62.git' }
-tonic = { git = 'https://github.com/liufuyang/tonic.git', branch = 'remote-timeout-header-from-reserved-list'}
+tonic = "0.4.1"
+# Using the below verion works as it removed "grpc-timeout" from restrictions
+# tonic = { git = 'https://github.com/hyperium/tonic.git', rev = '0b535985c8ea78a21e8516f809fac8a4cd86f854'}
 prost = "0.7.0"
 prost-types = "0.7.0"
 tokio = { version = "1.0", features = ["rt-multi-thread", "time", "fs", "macros", "net"] }
+http = "0.2"
+tower-service = "0.3"
 
 [build-dependencies]
 tonic-build = "0.4.1"


### PR DESCRIPTION
I was told to use something like [this](https://github.com/hyperium/tonic/blob/master/examples/src/tower/server.rs#L74) to do a "hack" in order to add `grpc-timeout` header onto the out going gRPC call.

And I also followed some code from [this PR](https://github.com/hyperium/tonic/pull/606/files)

But still this solution is not working for me?
The only thing that works for me is a tonic version that doesn't having `grpc-timeout` in the restrict list.

The output of my server looks like this with the PR change:
```
Server listening on [::1]:50052
call block req: {"content-type": "application/grpc", "user-agent": "grpcurl/1.8.0 grpc-go/1.30.0", "te": "trailers", "grpc-timeout": "5S"}
Got a request from Some([::1]:60981)
Request -> Request { metadata: MetadataMap { headers: {"grpc-timeout": "5S"} }, message: GetTrackRequest { gid: "3ff764c7c652446cbd79c05cfd8f59a7", country: "US", catalogue: "free", accept_language: [], preview: true, etag: [], view: Default }, extensions: Extensions }
interceptor block req: MetadataMap { headers: {"grpc-timeout": "5S", "spotify-userinfo-bin": "IgJ1c3IgY2RiM2EzOTA4NWEzNDg2MzkxZDA1NDIxMWUwZTUyOGM="} }
```

And the output of calling onto this server:
```
 grpcurl -plaintext -import-path ./proto -proto trackinfo.proto     -d '{"trackId": "1WHzHtbCV4OoB0TLgG7eMD"}'         localhost:50052 spotify.goldenpathexamples.GoldenPathExampleService/TrackToString
ERROR:
  Code: Aborted
  Message: No deadline specified
```

The reason is that the remote Spotify grpc server is requiring `"grpc-timeout"` in the header but I am not sure how to add it with the hack.